### PR TITLE
Fix handling of space in executable path

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function focusWindowByName(processName) {
 function executeProcess(arg, callback, mapper) {
     callback = callback || noop;
 
-    exec(windowsFocusManagementBinary + " " + arg, (error, stdout, stderr) => {
+    exec('"' + windowsFocusManagementBinary + '" ' + arg, (error, stdout, stderr) => {
         if (error) {
             callback(error, null);
             return;


### PR DESCRIPTION
Fix issue #9 by surrounding the executable path with ".

Otherwise you get the following error:
```
{ Error: Command failed: C:\Program Files\app\resources\app.asar\node_modules\node-process-windows\windows-console-app\windows-console-app\bin\Release\windows-console-app.exe --processinfo
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.

    at ChildProcess.exithandler (child_process.js:287:12)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Socket.stream.socket.on (internal/child_process.js:346:11)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at Pipe._handle.close [as _onclose] (net.js:554:12)
  killed: false,
  code: 1,
  signal: null,
  cmd: 'C:\\Program Files\\app\\resources\\app.asar\\node_modules\\node-process-windows\\windows-console-app\\windows-console-app\\bin\\Release\\windows-console-app.exe --processinfo' }
```